### PR TITLE
Add tasks plan for document processing pipeline

### DIFF
--- a/specs/document-processing-pipeline/design.md
+++ b/specs/document-processing-pipeline/design.md
@@ -1,0 +1,139 @@
+# Document Processing Pipeline Design
+
+## 1. Overview
+This design describes how to implement the eight-step regulatory document processing pipeline defined in the requirements. The solution enhances the existing `regulatory_processor` package by orchestrating file management, document transformation, and export operations driven by a mapping Excel file. The processor must run in batch mode, tolerate per-document failures, and generate Annex-specific deliverables in DOCX and PDF formats.
+
+## 2. Goals and Non-Goals
+### Goals
+- Automate the end-to-end pipeline for every document/mapping row pair (Reqs 1–8).
+- Preserve document formatting, hyperlinks, and structure while injecting updated national reporting content.
+- Provide clear logging, statistics, and recoverable error handling for large batches.
+- Make PDF conversion optional/configurable while defaulting to enabled behavior.
+
+### Non-Goals
+- Editing input mapping files or validating their business accuracy beyond structural checks.
+- Providing a GUI workflow (the existing Reflex app can invoke the API but UI changes are out of scope).
+- Supporting non-DOCX inputs or Annex types beyond I and IIIB.
+
+## 3. High-Level Architecture
+The design builds on the existing modular layout. Key components interact as follows:
+
+```mermaid
+graph TD
+    A[CLI / Reflex UI] -->|config + paths| B(DocumentProcessor)
+    B --> C[FileManager]
+    B --> D[MappingTable]
+    B --> E[DocumentUpdater]
+    B --> F[DocumentSplitter]
+    B --> G[DateFormatterSystem]
+    B --> H[LocalRepresentativeUpdater]
+    F --> I[OutputWriter]
+    H --> E
+    D --> E
+    D --> G
+    D --> H
+    C --> B
+    C --> I
+```
+
+- **DocumentProcessor** orchestrates iteration over discovered files and coordinates subcomponents.
+- **FileManager** validates inputs, sets up output folders, creates backups, and handles PDF conversion.
+- **MappingTable** loads and caches the Excel data, exposing row lookups by country/language or filename pattern.
+- **DocumentUpdater** handles SmPC/PL block replacement, target text removal, hyperlink formatting, and general docx manipulation.
+- **DateFormatterSystem** formats dates according to locale-aware templates from the mapping file.
+- **LocalRepresentativeUpdater** isolates relevant rows within the representative table.
+- **DocumentSplitter** extracts Annex I/IIIB segments and produces new DOCX files via `python-docx` cloning helpers.
+
+## 4. Data Model and Configuration
+- **ProcessingConfig** (existing) will gain flags for optional PDF conversion, backup behavior, overwrite policy, and logging level. Defaults follow requirements (PDF conversion on, backups enabled, overwrite disabled).
+- **MappingRow** (new dataclass) encapsulates parsed mapping values for a document, including lists for multi-country fields (`countries`, `smpc_lines`, `pl_append_text`, `hyperlinks`, `emails`, `local_rep_countries`, etc.). It normalizes semicolon-delimited cells, trimming whitespace and preserving order to align per-country columns.
+- **ProcessingStats** (existing) enhanced to track counts for successes, warnings, skipped documents, PDF failures, and annex splits.
+
+## 5. File Discovery & Validation (Req 1)
+1. `FileManager.discover_processable_documents(input_dir)` returns docx paths matching naming convention regex `^(?P<product>.+?)_(?P<country>[A-Z]{2})_(?P<language>[A-Z]{2}).docx$` (configurable).
+2. `MappingTable.load(path)` reads Excel via pandas, validates required columns, and precomputes dictionaries keyed by `(country_code, language)` and by filename prefix if provided.
+3. For each discovered file, `DocumentProcessor` extracts country/language, queries `MappingTable`. On failure, log and move file to `errors` folder.
+4. Output directories created under `/output/{timestamp}/{country_group}/docx|pdf` and backups stored adjacent to original unless configuration overrides.
+
+## 6. Per-Document Processing Flow
+```mermaid
+graph LR
+    A[Load DOCX] --> B[Apply MappingRow]
+    B --> C[Build SmPC Blocks]
+    C --> D[Replace Target Texts]
+    D --> E[Update Dates]
+    E --> F[Filter Local Reps]
+    F --> G[Split Annexes]
+    G --> H[Write Outputs]
+    H --> I[Convert PDFs]
+```
+
+### 6.1 SmPC/PL Block Construction (Reqs 2–4)
+- **Input**: `MappingRow.countries`, `MappingRow.smpc_lines`, `MappingRow.hyperlinks`, `MappingRow.emails`.
+- For each country index `i`:
+  - Build `CountryBlock` data structure with `name`, ordered `lines`, `hyperlinks`, `emails`.
+  - Validate that hyperlink/email substrings appear in respective lines; if not, record warning but continue.
+  - Use `python-docx` to create paragraphs with controlled formatting: first line bold (country name), subsequent lines normal text. Hyperlinks inserted via helper that creates relationship IDs (reuse `document_utils.create_hyperlink`). Email addresses use `mailto:` scheme.
+- Compose block paragraphs with `\n` separators converted to separate paragraphs. Between blocks insert empty paragraph (double line break effect).
+- Persist built blocks for reuse in PL section plus appended text (from `MappingRow.pl_append_text`).
+
+### 6.2 Target Text Replacement (Req 4)
+- Identify SmPC and PL target text runs using mapping columns (e.g., `Original text national reporting - SmPC/PL`). Implementation uses `document_utils.find_text_runs(document, target_text)` returning start/end run indexes.
+- Remove existing runs and insert block paragraphs using `document_utils.replace_runs_with_paragraphs` helper to preserve style context.
+- Insert appended PL text after entire block set. If appended text contains hyperlink placeholders, apply same detection logic.
+
+### 6.3 Date Updates (Req 5)
+- `DateFormatterSystem` obtains locale metadata using mapping row: `Annex I Date Format`, `Annex IIIB Date Format`, plus header strings.
+- `DocumentUpdater.update_annex_date(document, header_text, format_pattern)` locates header by normalized comparison (case-insensitive, trimmed). For Annex I, replace next paragraph text with formatted date. For Annex IIIB, replace placeholder token within the paragraph matching `Annex IIIB Date Text` (e.g., string with `{DATE}` placeholder) using regular expressions while preserving surrounding runs and style.
+- Date sources default to processing date; allow override for testing via config.
+
+### 6.4 Local Representative Table Filtering (Req 6)
+- Locate table containing "Local Representative" header. Iterate rows/cells searching for paragraphs where text matches one of the mapping countries (case-insensitive, after removing accents optionally).
+- Identify contiguous paragraphs constituting a country block by scanning until next bold paragraph or blank line. Use `python-docx` style info to maintain bolding for country names; ensure bold formatting applied using mapping-provided display names.
+- Remove table rows/cells not in selected set. If a required country block absent, log warning and proceed.
+
+### 6.5 Annex Splitting (Req 7)
+- Use `DocumentSplitter.find_header_positions(document, headers)` to locate indexes for Annex I, Annex II, Annex IIIB based on mapping-provided localized strings. Implement tolerance for uppercase, whitespace, numbering variations by normalizing text and using regex like `r"^annex\s+i\b"` or localized equivalent.
+- Extract document portions: Annex I = start to Annex II header, Annex IIIB = Annex IIIB header to end. Create new `Document` objects by cloning relevant elements (paragraphs, tables, headers/footers) using docx XML deep copy to maintain formatting.
+- Determine combined country list string (e.g., `Ireland_Malta`). Generate filenames accordingly and ensure uniqueness via FileManager (append `_v2` if conflict).
+
+### 6.6 Output Writing & PDF Conversion (Req 8)
+- Save Annex DOCX files into `output_root/<country_group>/docx/`.
+- If `config.convert_to_pdf` true, call `FileManager.convert_to_pdf(docx_path, pdf_path)` using `docx2pdf` by default, fallback to LibreOffice CLI on failure. Capture errors; mark `ProcessingStats.pdf_failures`.
+- Maintain manifest JSON or CSV summarizing original file, annex outputs, statuses.
+
+## 7. Error Handling and Logging
+- Use structured logging with per-document context (document name, country list).
+- Wrap each major step in try/except; raise `DocumentError` for non-recoverable issues (e.g., corrupted docx). For recoverable warnings (missing hyperlink text) use `logger.warning` and continue.
+- Collect warnings in `ProcessingResult.warnings` list returned to caller for UI display.
+- Ensure partial outputs cleaned up on failure to avoid orphaned files.
+
+## 8. Performance Considerations
+- Reuse loaded mapping data across documents; avoid re-reading Excel per document.
+- Minimize repeated docx saves by batching modifications before writing once per annex.
+- Optionally parallelize per-document processing in future (out of scope now) but design ensures components stateless or using thread-safe data.
+
+## 9. Testing Strategy
+- **Unit Tests**: Cover parsing of mapping rows, hyperlink insertion helpers, date formatter patterns, annex splitter header detection, and local representative filtering logic.
+- **Integration Tests**: Use fixture DOCX files representing single-country and multi-country scenarios to assert final document structure, inserted text, and hyperlink existence. Validate Annex splitting results and naming conventions.
+- **Regression Tests**: Process sample batch verifying stats, log outputs, PDF conversion fallback behavior (mock external converters).
+- **Manual QA**: Spot-check generated DOCX/PDF files for formatting fidelity, hyperlink functionality, and date localization for each supported language.
+
+## 10. Deployment & Configuration
+- Expose pipeline via CLI command (e.g., `python -m regulatory_processor.processor --input ...`) and ensure Reflex UI can set configuration flags.
+- Document configuration options in README/spec to guide operations teams.
+- Provide environment variable overrides for converter paths (LibreOffice) and logging settings.
+
+## 11. Traceability Matrix
+| Requirement | Design Section(s) |
+|-------------|-------------------|
+| Req 1 | Sections 5, 10 |
+| Req 2 | Sections 4, 5, 6.1 |
+| Req 3 | Sections 4, 6.1 |
+| Req 4 | Section 6.2 |
+| Req 5 | Section 6.3 |
+| Req 6 | Section 6.4 |
+| Req 7 | Section 6.5 |
+| Req 8 | Sections 6.6, 10 |
+| Non-Functional | Sections 3, 7, 8, 9 |
+| Open Questions | Sections 5 (behavior), 6.6 (PDF toggle), 10 (backup handling), 6.1 (hyperlink variants), 6.5 (header heuristics) |

--- a/specs/document-processing-pipeline/requirements.md
+++ b/specs/document-processing-pipeline/requirements.md
@@ -1,0 +1,60 @@
+# Document Processing Pipeline Requirements
+
+## Feature Overview
+Automate the eight-step regulatory document pipeline described by the user so that SmPC/PL Word documents are transformed, split, and exported with country-specific content and metadata.
+
+## User Stories
+- As a regulatory operations specialist, I want to load input documents and their mapping file so that the processor can prepare country-specific updates automatically.
+- As a regulatory operations specialist, I want the system to identify each document's country/language mapping so that the correct template data is used.
+- As a regulatory operations specialist, I want national reporting blocks regenerated with proper formatting so that SmPC and PL sections contain accurate hyperlinks and contacts.
+- As a regulatory operations specialist, I want outdated SmPC/PL target text removed and replaced with insertion blocks so that the documents reflect current national reporting instructions.
+- As a regulatory operations specialist, I want the Annex I and Annex IIIB dates refreshed per locale so that the documents comply with language-specific formatting rules.
+- As a regulatory operations specialist, I want local representative tables filtered to the relevant countries so that each document only lists the required contacts.
+- As a regulatory operations specialist, I want combined SmPC/PL documents split into Annex I and Annex IIIB versions so that downstream workflows receive the correct files.
+- As a regulatory operations specialist, I want generated Annex files exported as DOCX and PDF and organized by country group so that the deliverables are easy to distribute.
+
+## Acceptance Criteria (EARS)
+1. **Document & Mapping Intake**  
+   - WHEN the user provides an input folder of DOCX files and a mapping Excel file THEN the processor SHALL validate their presence, structure, and required columns before continuing.
+   - WHEN validation fails THEN the processor SHALL log the failure and skip the affected document without terminating the entire batch.
+
+2. **Country/Language Mapping**  
+   - WHEN a document filename matches a mapping row THEN the processor SHALL associate the document with the row's country group and language.  
+   - WHEN a mapping row specifies multiple countries delimited by semicolons THEN the processor SHALL treat each country as a separate insertion block within that document.
+
+3. **SmPC Country Block Construction**  
+   - WHEN constructing the SmPC reporting block THEN the processor SHALL create one formatted block per country consisting of bolded country name, ordered lines, and hyperlinks rendered for URLs and email addresses defined in the mapping file.  
+   - WHEN any hyperlink text is missing from the document lines THEN the processor SHALL raise a recoverable warning and continue processing the document.
+
+4. **Target Text Replacement**  
+   - WHEN the SmPC/PL target text segment is detected in the document THEN the processor SHALL remove it and insert the newly built country blocks separated by double line breaks between countries and single line breaks at the boundaries.  
+   - WHEN the target text cannot be located THEN the processor SHALL log a warning and leave the document unchanged for that segment.
+
+5. **Date Updates**  
+   - WHEN Section 10 (Annex I) and Section 6 (Annex IIIB) are processed THEN the processor SHALL replace the date text using the locale-specific headers, formats, and replacement templates supplied in the mapping row.  
+   - WHEN a section header or placeholder cannot be found THEN the processor SHALL log the exception and keep existing text unchanged.
+
+6. **Local Representative Filtering**  
+   - WHEN the document contains a local representative table THEN the processor SHALL retain only rows/cells whose country names appear in the mapping row while preserving formatting and bolding required for the selected countries.  
+   - WHEN the required country block is absent THEN the processor SHALL flag the document for manual review while continuing with remaining steps.
+
+7. **Annex Splitting & Naming**  
+   - WHEN Annex headers are detected in the document THEN the processor SHALL produce separate Annex I and Annex IIIB DOCX outputs with names following `[Annex]_EU_SmPC_[Language]_[Country(s)].docx`.  
+   - WHEN multiple countries are associated with the document THEN the processor SHALL include the combined country list in the generated filename and ensure content coverage for all listed countries.
+
+8. **PDF Conversion & Output Organization**  
+   - WHEN DOCX annex outputs are produced THEN the processor SHALL (optionally) convert each to PDF and store the DOCX and PDF versions under folders grouped by country group with subfolders for each file type.  
+   - WHEN PDF conversion fails THEN the processor SHALL retain the DOCX, log the error, and continue processing subsequent files.
+
+## Non-Functional Requirements
+- The processor SHALL support batch execution with progress logging and per-document error isolation.
+- The processor SHALL preserve original documents by creating backups prior to modification when configured to do so.
+- The processor SHALL maintain hyperlink functionality and formatting integrity in the generated DOCX and PDF outputs.
+- The processor SHOULD finish processing a standard batch of 50 documents in under 15 minutes on reference hardware (to be refined during testing).
+
+## Open Questions
+1. How should the processor behave when the mapping file references countries not present in the input batch—log warning only or raise exception?  
+2. Is PDF conversion mandatory for all runs or can users disable it via configuration at runtime?  
+3. Should backup `.orig` files also be organized into the country-based folder structure or remain in-place next to the source documents?  
+4. Are there any country-specific exceptions for hyperlink formatting (e.g., display text differs from URL/email) that must be supported beyond direct substitutions?  
+5. What is the expected behavior when Annex II headers are missing or mislabeled—should the splitter fall back to heuristics or fail the document?

--- a/specs/document-processing-pipeline/tasks.md
+++ b/specs/document-processing-pipeline/tasks.md
@@ -1,0 +1,28 @@
+# Document Processing Pipeline Tasks
+
+## 1. Foundation & Configuration
+- [ ] 1.1 Update `ProcessingConfig` defaults and flags for backups, PDF conversion, overwrite policy, and logging level; adjust `ProcessingResult/ProcessingStats` to capture new counters (Req 1, Req 8, Non-Functional).
+- [ ] 1.2 Implement `MappingTable` loader that validates required columns and builds lookup dictionaries by `(country_code, language)` and filename pattern (Req 1).
+- [ ] 1.3 Create `MappingRow` dataclass parsing semicolon-delimited fields into ordered lists for countries, SmPC lines, hyperlinks, emails, PL append text, and local representative countries (Req 2, Req 3, Req 6).
+
+## 2. SmPC & PL Block Processing
+- [ ] 2.1 Build helper functions in `document_utils` to construct country insertion blocks with bold country names, formatted lines, and hyperlink/email conversion; emit warnings when substrings missing (Req 3).
+- [ ] 2.2 Update `DocumentUpdater` to replace SmPC/PL target text runs with generated blocks, handling block separation and appended PL text while logging warnings when target text absent (Req 4).
+
+## 3. Date Updates
+- [ ] 3.1 Extend `DateFormatterSystem` to support locale-specific patterns, month localization, and configurable processing date; integrate Annex I/IIIB update methods that use mapping headers/placeholders (Req 5).
+
+## 4. Local Representative Filtering
+- [ ] 4.1 Implement `LocalRepresentativeUpdater` logic to detect country blocks inside representative tables, keep only mapping-listed countries, and enforce bold formatting of country names (Req 6).
+
+## 5. Annex Splitting & Output
+- [ ] 5.1 Enhance `DocumentSplitter` to locate Annex headers using localized strings and produce Annex I/IIIB documents while preserving formatting (Req 7).
+- [ ] 5.2 Implement output filename generator and folder organization per country group, including manifest updates and uniqueness handling (Req 7, Req 8).
+
+## 6. PDF Conversion & Finalization
+- [ ] 6.1 Integrate optional PDF conversion pipeline with fallback strategy, recording failures without aborting processing (Req 8).
+- [ ] 6.2 Wire all components together in `DocumentProcessor` main loop: discover documents, resolve mapping rows, execute processing steps with error handling, manage backups, and update statistics (Req 1–8, Non-Functional).
+
+## 7. Testing
+- [ ] 7.1 Author unit tests for mapping parsing, hyperlink creation, date formatting, representative filtering, and annex splitting behaviors (Req 1–7).
+- [ ] 7.2 Add integration tests covering single-country and multi-country document scenarios, including PDF conversion toggling and error handling (Req 1–8, Non-Functional).


### PR DESCRIPTION
## Summary
- add tasks.md outlining actionable implementation checklist for the document processing pipeline

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cc7d2829b083298c849f6f8b34c70f